### PR TITLE
Use process env variable check for loading modules

### DIFF
--- a/frontend/WikiContrib-Frontend/src/index.js
+++ b/frontend/WikiContrib-Frontend/src/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import App from './App';
-import { production } from './App';
 import * as serviceWorker from './serviceWorker';
-if (production) {
+
+if (process.env.NODE_ENV === 'production') {
   require('./dist/semantic.min.css');
 } else {
   require('semantic-ui-css/semantic.min.css');


### PR DESCRIPTION
Fixes https://github.com/wikimedia/WikiContrib/issues/33. 

(Sidenote: I am not sure if there is a reason why we are using `production` variable in some files and `process.env.NODE_ENV` in others. If it's intentional that's okay, if not then at some point code can be refactored)