### PR TITLE
Minor tweak of info popover

### DIFF
--- a/frontend/WikiContrib-Frontend/src/api.js
+++ b/frontend/WikiContrib-Frontend/src/api.js
@@ -185,6 +185,6 @@ export const getPadding = () => {
 };
 
 
-export const info_content = "The tool provides user activity from two platforms(Phabricator, \
+export const info_content = "The tool provides user activity from two platforms (Phabricator and \
                 Gerrit) and display it. It fetches the contributions of the user in specified time span and \
                 visualize the data in form of graphs";


### PR DESCRIPTION
1. Add space between "platforms" and "("

2. Use conjunction instead of comma since we have just two items