### PR TITLE
fixed "PORT" to "DB_PORT" issue

### DIFF
--- a/backend/Contraband/contraband/.env.example
+++ b/backend/Contraband/contraband/.env.example
@@ -7,7 +7,7 @@ DB_NAME_REMOTE=TEST_DATABASE
 DB_USER=TEST_USER
 DB_PASSWORD=TEST_PASSWORD
 HOST=tools.db.svc.eqiad.wmflabs
-PORT=3306
+DB_PORT=3306
 BASE_URL_REMOTE=http://tools.wmflabs.org/contraband/
 
 PHAB_KEY=api-xxxxyyyyzzzz

--- a/backend/Contraband/contraband/settings.py
+++ b/backend/Contraband/contraband/settings.py
@@ -91,7 +91,7 @@ DATABASES = {
         'USER': env('DB_USER'),
         'PASSWORD': env('DB_PASSWORD'),
         'HOST': env('HOST'),
-        'PORT': env('PORT'),
+        'PORT': env('DB_PORT'),
     }
 }
 


### PR DESCRIPTION
Tasks successfully completed:

## The variable named PORT is renamed to DB_PORT in .env.example file.
## The variable named PORT in settings.py file is replaced by env('PORT').
