### PR TITLE
Fix Internal server error(500) while creating new query.

### DIFF
--- a/backend/Contraband/query/views.py
+++ b/backend/Contraband/query/views.py
@@ -135,7 +135,7 @@ class AddQueryUser(CreateAPIView):
                         # Add the Query
                         query = super(AddQueryUser, self).post(request, *args, **kwargs)
                         filter_time = timezone.now().date()
-                        filter_time = filter_time.replace(day=1, month=filter_time.month+1)
+                        filter_time = filter_time.replace(day=1, month=(filter_time.month%12)+1)
                         QueryFilter.objects.create(
                             query=get_object_or_404(Query, hash_code=query.data['hash_code']),
                             start_time=filter_time - timedelta(days=365),


### PR DESCRIPTION
There is a indeterminate breakage of server recently. It was presumed that updating the server is the reason. But the actual reason is:

```python
# L138 in views.py file of query app
filter_time = filter_time.replace(day=1, month=filter_time.month+1)
```

On taking a specific date in december, `filter_time.month+1` gives out 13 as a result (as the 13th month does not exist). So, the server responds with a **ValueError**.

Thanks @JanStevcik for informing about the issue through [this](https://github.com/wikimedia/WikiContrib/pull/63#issuecomment-560933728).