### PR TITLE
Improved accessibility to 100% lighthouse rating

### DIFF
--- a/frontend/WikiContrib-Frontend/src/App.css
+++ b/frontend/WikiContrib-Frontend/src/App.css
@@ -235,7 +235,6 @@ h4.accounts {
 }
 
 .ui.button.table_row_add {
-  float: right;
   background: #222 !important;
   color: white !important;
   padding: 17px !important;
@@ -252,13 +251,22 @@ h4.accounts {
 
 .ui.button.table_row_add:hover,
 .ui.button.continue:hover,
-.ui.button.save_offline:hover {
+.ui.button.save_offline:hover,
+.ui.button.reset:hover,
+.ui.button.table_row_add:focus,
+.ui.button.continue:focus,
+.ui.button.save_offline:focus,
+.ui.button.reset:focus
+ {
   opacity: 0.8;
+  -webkit-box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  -moz-box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  outline: 2px solid white;
 }
 
 .ui.button.continue,
 .ui.button.save_offline {
-  float: right;
   background: #36c !important;
   color: white !important;
   padding: 17px !important;
@@ -276,8 +284,11 @@ h4.accounts {
   width: 100% !important;
 }
 
-.ui.button.reset {
+.reset_add_continue {
   float: right;
+}
+
+.ui.button.reset {
   background: #d33 !important;
   color: white !important;
   padding: 17px !important;
@@ -454,8 +465,12 @@ h4.accounts {
   opacity: 1;
 }
 
-.ui.icon.button.filters:hover {
+.ui.icon.button.filters:hover,.ui.icon.button.filters:focus {
   opacity: 0.8;
+  -webkit-box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  -moz-box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  outline: 2px solid white;
 }
 
 .ui.card.filter_view {
@@ -533,8 +548,12 @@ h4.accounts {
   margin-left: -50%;
 }
 
-.ui.icon.button.update_query:hover {
+.ui.icon.button.update_query:hover,.ui.icon.button.update_query:focus {
   opacity: 0.8;
+  -webkit-box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  -moz-box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  box-shadow: 0px 0px 5px 6px rgba(0,0,0,0.43);
+  outline: 2px solid white;
 }
 
 .line.load_background {
@@ -612,18 +631,33 @@ h4.accounts {
   border: 1px solid #C3C4C4;
 }
 
-.ui.button.docs {
+/* .ui.button.docs {
   background: #eaecf0 !important;
   color: #222 !important;
   padding-left: 10px !important;
   padding-right: 8px !important;
   margin-right: -25px;
-}
+} */
+
+  .a.docs {
+    background: #eaecf0;
+    color: #222;
+    padding-left: 10px;
+    padding-right: 8px;
+    padding-top: 8px;
+    padding-bottom: 10px;
+    border-radius: 4px;
+    margin-right: -25px;
+  }
 
 .ui.button.info {
   background: #eaecf0 !important;
   color: #222 !important;
   margin-right: -15px !important;
+}
+
+.ui.button.info:focus {
+  outline: 2px solid #9ABDF6;
 }
 
 .card{
@@ -659,4 +693,22 @@ h4.accounts {
   white-space: nowrap;
   flex-direction: row-reverse;
   align-items: center;
+}
+
+
+
+.input_label {
+  text-align: left;
+  margin-top: 1.5em;
+  margin-bottom:0.5em;
+  padding-left: 1.4rem;
+  font-weight: bold;
+}
+
+.checkbox_label {
+  display: inline-block;
+  font-weight: bold;
+  color: black;
+  position: absolute;
+  margin-left: 1em;
 }

--- a/frontend/WikiContrib-Frontend/src/App.css
+++ b/frontend/WikiContrib-Frontend/src/App.css
@@ -712,3 +712,7 @@ h4.accounts {
   position: absolute;
   margin-left: 1em;
 }
+
+.ui.button.remove:focus,.ui.button.remove:hover {
+  outline: 2px solid #9ABDF6 !important;
+}

--- a/frontend/WikiContrib-Frontend/src/components/dropdown.js
+++ b/frontend/WikiContrib-Frontend/src/components/dropdown.js
@@ -27,9 +27,10 @@ class Dropdown extends React.Component {
                 style={{ marginTop: 3, marginRight: 2 }}
               />
             ) : (
-              <Icon name="search" style={{ marginTop: 3 }} />
+              <Icon name="search" id="search" label="search" style={{ marginTop: 3 }} />
             )}
             <input
+              aria-label="search"
               onKeyPress={e => {
                 if (e.which === 13) {
                   this.props.onSearchChange();
@@ -63,7 +64,7 @@ class Dropdown extends React.Component {
           {this.state.open ? (
             <div className="dropdown_max_len">
               {this.state.loading ? (
-                <div className="message_dropdown">
+                <div className="message_dropdown" id="message_dropdown">
                   {this.props.noResultsMessage}
                 </div>
               ) : (

--- a/frontend/WikiContrib-Frontend/src/components/nav.js
+++ b/frontend/WikiContrib-Frontend/src/components/nav.js
@@ -6,26 +6,23 @@ export const NavBar = () => (
   <Menu fluid secondary style={{ marginTop: -5 }}>
     <Menu.Menu position="right">
       <Menu.Item>
-        <a
+        <a className="a docs"
           target="_blank"
           href="https://wikicontrib.readthedocs.io/en/latest/"
           rel="noopener noreferrer"
         >
-          <Button className="docs">
             <span style={{ marginRight: 5 }}>Docs</span> <Icon name="book" />
-          </Button>
         </a>
       </Menu.Item>
       <Menu.Item>
         <Popup
-          trigger={<Button icon="info" size="large" className="info"></Button>}
+          trigger={<Button icon="info" tabIndex="0" aria-describedby="info_content" size="large" className="info"></Button>}
           position="bottom right"
           content={
-            <div style={{ textAlign: 'center' }}>
-              <span style={{ fontFamily: 'Charter', fontWeight: 'bold' }}>
+            <div id="info_content" style={{ textAlign: 'center' }}>
+              <h2 style={{ fontFamily: 'Charter', fontWeight: 'bold' }}>
                 WikiContrib
-              </span>
-              <br />
+              </h2>
               <p>{info_content}</p>
             </div>
           }

--- a/frontend/WikiContrib-Frontend/src/components/nav.js
+++ b/frontend/WikiContrib-Frontend/src/components/nav.js
@@ -7,6 +7,7 @@ export const NavBar = () => (
     <Menu.Menu position="right">
       <Menu.Item>
         <a className="a docs"
+        aria-label="read the documentation"
           target="_blank"
           href="https://wikicontrib.readthedocs.io/en/latest/"
           rel="noopener noreferrer"
@@ -16,7 +17,7 @@ export const NavBar = () => (
       </Menu.Item>
       <Menu.Item>
         <Popup
-          trigger={<Button icon="info" tabIndex="0" aria-describedby="info_content" size="large" className="info"></Button>}
+          trigger={<Button icon="info" aria-label="about wikicontrib" tabIndex="0" size="large" className="info"></Button>}
           position="bottom right"
           content={
             <div id="info_content" style={{ textAlign: 'center' }}>

--- a/frontend/WikiContrib-Frontend/src/query.js
+++ b/frontend/WikiContrib-Frontend/src/query.js
@@ -462,7 +462,7 @@ export class Query extends Component {
                       animation="fade"
                     >
                       <React.Fragment>
-                        <Header className="title">WikiContrib</Header>
+                        <h1><Header className="title">WikiContrib</Header></h1>
                         <h4 className="accounts">
                           Get the Contributions of your fellow Wikimedians,
                           showcase yourself! Visualize their contribs using

--- a/frontend/WikiContrib-Frontend/src/query.js
+++ b/frontend/WikiContrib-Frontend/src/query.js
@@ -491,11 +491,11 @@ export class Query extends Component {
                                   onClose={(event) => {
                                     // in case of bulkTooltipShown being false (currently open)
                                     // the event fired when click would be onClose
-                                    if(this.state.bulkTooltipShown || (event.target.tagName.toLowerCase() !== 'i')) 
+                                    if(this.state.bulkTooltipShown || (event.target.tagName.toLowerCase() !== 'i'))
                                       // if tooltip already finished, close normally
-                                      this.setState({ bulkShown: false, bulkTooltipShown: true }) 
+                                      this.setState({ bulkShown: false, bulkTooltipShown: true })
                                     else
-                                      // if tooltip not finished, 
+                                      // if tooltip not finished,
                                       // we will not close
                                       // but set tooltip to be finished and show the info normally
                                       // (a click here means open the CSV info)
@@ -679,6 +679,8 @@ export class Query extends Component {
                                       <Table.Cell
                                         style={{ textAlign: 'center' }}
                                       >
+                                      <label>
+                                        <div className="input_label">Full Name</div>
                                         <input
                                           className="user_input"
                                           value={obj.fullname}
@@ -692,53 +694,65 @@ export class Query extends Component {
                                             )
                                           }
                                         />
+                                    </label>
                                       </Table.Cell>
                                       <Table.Cell
                                         style={{ textAlign: 'center' }}
                                       >
-                                        <input
-                                          className="user_input"
-                                          value={obj.gerrit_username}
-                                          name="gerrit_username"
-                                          placeholder="Gerrit Username"
-                                          onChange={e =>
-                                            this.handlChange(
-                                              e.target.name,
-                                              e.target.value,
-                                              index
-                                            )
-                                          }
-                                        />
+                                        <label>
+                                          <div className="input_label">Gerrit Username</div>
+                                          <input
+                                            className="user_input"
+                                            value={obj.gerrit_username}
+                                            name="gerrit_username"
+                                            placeholder="Gerrit Username"
+                                            onChange={e =>
+                                              this.handlChange(
+                                                e.target.name,
+                                                e.target.value,
+                                                index
+                                              )
+                                            }
+                                          />
+                                        </label>
                                       </Table.Cell>
                                       <Table.Cell
                                         style={{ textAlign: 'center' }}
                                       >
-                                        <input
-                                          className="user_input"
-                                          value={obj.phabricator_username}
-                                          name="phabricator_username"
-                                          placeholder="Phabricator Username"
-                                          onChange={e =>
-                                            this.handlChange(
-                                              e.target.name,
-                                              e.target.value,
-                                              index
-                                            )
-                                          }
-                                        />
+                                        <label>
+                                          <div className="input_label">Phabricator Username</div>
+                                          <input
+                                            className="user_input"
+                                            value={obj.phabricator_username}
+                                            name="phabricator_username"
+                                            placeholder="Phabricator Username"
+                                            onChange={e =>
+                                              this.handlChange(
+                                                e.target.name,
+                                                e.target.value,
+                                                index
+                                              )
+                                            }
+                                          />
+                                        </label>
                                       </Table.Cell>
                                       <Table.Cell
-                                        style={{ textAlign: 'center' }}
+                                        tabIndex="0" style={{ textAlign: 'center' }}
                                       >
+                                      <Button style={{backgroundColor:"inherit"}}
+                                        onClick={(e)=>{
+                                          this.removeRow(index);
+                                        }}>
                                         <Icon
                                           name="minus circle"
+                                          label="remove row"
                                           style={{
                                             cursor: 'pointer',
                                             color: '#fa5050',
                                             fontSize: '1rem',
                                           }}
-                                          onClick={() => this.removeRow(index)}
                                         />
+                                      </Button>
                                       </Table.Cell>
                                     </Table.Row>
                                   ))}
@@ -749,49 +763,55 @@ export class Query extends Component {
                           <br />
                           <Card.Content extra>
                             <div>
-                              <Checkbox
-                                toggle
-                                label="Bulk Add"
-                                onClick={() =>
-                                  this.setState({ bulk: !this.state.bulk })
-                                }
-                                checked={this.state.bulk}
-                              />
+                              <label>
+                                <Checkbox
+                                  toggle
+                                  onClick={() =>
+                                    this.setState({ bulk: !this.state.bulk })
+                                  }
+                                  checked={this.state.bulk}
+                                />
+                              <span className="checkbox_label">Bulk Add</span>
+                              </label>
                             </div>
                           </Card.Content>
                         </Card>
-                        <Button
-                          onClick={this.createQuery}
-                          className="continue"
-                          disabled={this.state.loading}
-                          loading={this.state.loading}
-                        >
-                          <Icon name="search" />
-                        </Button>
-                        <Button className="table_row_add" onClick={this.addrow}>
-                          <Icon name="user plus" />
-                        </Button>
-                        <Button
-                          icon
-                          className="reset"
-                          onClick={() => {
-                            localStorage.removeItem('users');
-                            this.setState({
-                              message: {
-                                message: 'Cleared the cache data!',
-                                trigger: true,
-                                type: 0,
-                                update: !this.state.message.update,
-                              },
-                              rows: [Object.assign({}, emptyObj)],
-                            });
-                          }}
-                        >
-                          <Icon
-                            name="trash alternate"
-                            style={{ paddingRight: 4 }}
-                          />
-                        </Button>
+                        <div className="reset_add_continue">
+                          <Button
+                            icon
+                            aria-label="reset"
+                            className="reset"
+                            onClick={() => {
+                              localStorage.removeItem('users');
+                              this.setState({
+                                message: {
+                                  message: 'Cleared the cache data!',
+                                  trigger: true,
+                                  type: 0,
+                                  update: !this.state.message.update,
+                                },
+                                rows: [Object.assign({}, emptyObj)],
+                              });
+                            }}
+                          >
+                            <Icon
+                              name="trash alternate"
+                              style={{ paddingRight: 4 }}
+                            />
+                          </Button>
+                          <Button className="table_row_add" aria-label="add more user" onClick={this.addrow}>
+                            <Icon name="user plus" />
+                          </Button>
+                          <Button
+                            onClick={this.createQuery}
+                            className="continue"
+                            disabled={this.state.loading}
+                            loading={this.state.loading}
+                            aria-label="search"
+                          >
+                            <Icon name="search" />
+                          </Button>
+                        </div>
                       </React.Fragment>
                     </Transition>
                   )}

--- a/frontend/WikiContrib-Frontend/src/query.js
+++ b/frontend/WikiContrib-Frontend/src/query.js
@@ -737,9 +737,10 @@ export class Query extends Component {
                                         </label>
                                       </Table.Cell>
                                       <Table.Cell
-                                        tabIndex="0" style={{ textAlign: 'center' }}
+                                       style={{ textAlign: 'center' }}
                                       >
-                                      <Button style={{backgroundColor:"inherit"}}
+                                      <Button className="remove" aria-label="remove user" style={{backgroundColor:"inherit"}}
+                                      tabIndex="0"
                                         onClick={(e)=>{
                                           this.removeRow(index);
                                         }}>

--- a/frontend/WikiContrib-Frontend/src/result.js
+++ b/frontend/WikiContrib-Frontend/src/result.js
@@ -462,6 +462,7 @@ class QueryResult extends React.Component {
             trigger={
               <div className="left_arrow">
                 <Button
+                  aria-label="previous user"
                   icon="arrow left"
                   className="page_button"
                   primary
@@ -483,6 +484,7 @@ class QueryResult extends React.Component {
               trigger={
                 <Button
                   primary
+                  aria-label="next user"
                   className="page_button"
                   icon="arrow right"
                   disabled={this.state.loading}
@@ -500,6 +502,7 @@ class QueryResult extends React.Component {
             <Grid.Column width={2} />
             <Grid.Column width={12}>
               <div className="result">
+              <h1 className="result_page_heading">Query Result</h1>
                 {this.state.page_load ? (
                   <Placeholder fluid className="search_load">
                     <Placeholder.Line className="load_background" />
@@ -531,6 +534,7 @@ class QueryResult extends React.Component {
                             <Button
                               icon="options"
                               className="filters"
+                              aria-label="filters"
                               onClick={() =>
                                 this.setState({
                                   view_filters: !this.state.view_filters,
@@ -554,6 +558,7 @@ class QueryResult extends React.Component {
                           trigger={
                             <Button
                               className="update_query"
+                              aria-label="update query"
                               icon="write"
                               as={Link}
                               to={


### PR DESCRIPTION
Task done:
Improved the accessibility of the tool from a 60-70% rating to 100% rating.
To get a feel of what was done, you can use the tab key to tab through the original site and then through the improved site.
Issue fixed: #115 

Initial:
![result_page_accessbility_report](https://user-images.githubusercontent.com/40905613/76368222-c2246800-632f-11ea-8997-b5bfa4476cb4.JPG)
![wiki_contrib_home_page_accessbility_report](https://user-images.githubusercontent.com/40905613/76368225-c3ee2b80-632f-11ea-8609-167ec3fcbea6.JPG)

Final:
![result_page_accessibility_report_passing](https://user-images.githubusercontent.com/40905613/76368239-d2d4de00-632f-11ea-8d56-01c3dc3214c0.JPG)
![home_page_accessibility_report_passing](https://user-images.githubusercontent.com/40905613/76368241-d49ea180-632f-11ea-8e2f-aa003d74cbf7.JPG)

The tool still needs deep accessibility for custom elements like the month by month contribution grids, but this is a good start.
I will be creating a PR to address that part, referencing this PR