### PR TITLE
fixed server error 500 while uploading csv with non-english characters

### DIFF
--- a/backend/WikiContrib/WikiContrib/urls.py
+++ b/backend/WikiContrib/WikiContrib/urls.py
@@ -1,5 +1,4 @@
 """WikiContrib URL Configuration
-
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/2.2/topics/http/urls/
 Examples:
@@ -28,4 +27,3 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
-

--- a/backend/WikiContrib/result/views.py
+++ b/backend/WikiContrib/result/views.py
@@ -255,7 +255,7 @@ class DisplayResult(APIView):
         if query.file:
             # get the data from CSV file
             try:
-                file = read_csv(query.csv_file)
+                file = read_csv(query.csv_file,encoding="latin-1")
                 try:
                     if 'user' in request.GET:
                         user = file[file['fullname'] == request.GET['user']]
@@ -386,7 +386,7 @@ class GetUsers(APIView):
         else:
             try:
                 try:
-                    file = read_csv(query.csv_file)
+                    file = read_csv(query.csv_file,encoding="latin-1")
                     users = file[(file['fullname'] == file['fullname']) &
                                  ((file['Phabricator'] == file['Phabricator']) | (file['Gerrit'] == file['Gerrit']))]
                     users = users.iloc[:, 0].values.tolist()
@@ -408,7 +408,7 @@ def UserUpdateTimeStamp(data):
     data['query'] = get_object_or_404(Query, hash_code=data['query'])
     if data['query'].file:
         try:
-            file = read_csv(data['query'].csv_file)
+            file = read_csv(data['query'].csv_file,encoding="latin-1")
             user = file[file['fullname'] == data['username']]
             if user.empty:
                 return Response({'message': 'Not Found', 'error': 1}, status=status.HTTP_404_NOT_FOUND)

--- a/frontend/WikiContrib-Frontend/src/api.js
+++ b/frontend/WikiContrib-Frontend/src/api.js
@@ -186,5 +186,5 @@ export const getPadding = () => {
   }
 };
 
-export const info_content = 
+export const info_content =
   "WikiContrib tool provides a visualization within a specified time range of users' contributions to Wikimedia projects on Phabricator and Gerrit."


### PR DESCRIPTION
the problem seems to be coming from pandas.read_csv() function. There was no specified encoding type, therefore it defaults to utf-8. utf-8 is good for English characters but doesn't work well with certain non-English characters.

**What I did**
added "encoding='latin-1' " anywhere pandas.read_csv() is being called

**issue involved**
#127 