### PR TITLE
Corrected all error messages

### DIFF
--- a/backend/WikiContrib/query/views.py
+++ b/backend/WikiContrib/query/views.py
@@ -284,7 +284,7 @@ class QueryRetrieveUpdateDeleteView(RetrieveUpdateDestroyAPIView):
                                 raise IntegrityError
                 except IntegrityError:
                     return Response({
-                        'message': 'Can not update with the empty fields',
+                        'message': 'Cannot update with the empty fields',
                         'error': 1
                     }, status=status.HTTP_400_BAD_REQUEST)
                 response = HttpResponse(content="", status=303)
@@ -296,7 +296,7 @@ class QueryRetrieveUpdateDeleteView(RetrieveUpdateDestroyAPIView):
 
         except KeyError:
             return Response({
-                "message": "Fill form completely!",
+                "message": "Fill the form completely!",
                 "error": 1
             }, status=status.HTTP_400_BAD_REQUEST)
 

--- a/backend/WikiContrib/result/views.py
+++ b/backend/WikiContrib/result/views.py
@@ -290,7 +290,7 @@ class DisplayResult(APIView):
                         next_user = get_next_user(file, ind)
                 except KeyError:
                     return Response({
-                        'message': 'CSV file you have uploaded is not in the supported format. Click on the &#9432; to check the format.(while uploading it)',
+                        'message': 'CSV file uploaded is not in the supported format. Click on ⓘ (Information icon) to check the format.',
                         'error': 1
                     }, status=status.HTTP_400_BAD_REQUEST)
             except FileNotFoundError:
@@ -392,7 +392,7 @@ class GetUsers(APIView):
                     users = users.iloc[:, 0].values.tolist()
                 except KeyError:
                     return Response({
-                        'message': 'CSV file you have uploaded is not in the supported format. Click on the &#9432; icon to check the format.',
+                        'message': 'CSV file uploaded is not in the supported format. Click on ⓘ (Information icon) to check the format.',
                         'error': 1
                     }, status=status.HTTP_400_BAD_REQUEST)
             except FileNotFoundError:


### PR DESCRIPTION
All Error Messages have been corrected for end User Experience (UX)

For example, when a CSV file with a wrong format is uploaded, earlier the error message displayed was - 'CSV file you have uploaded is not in the supported format. Click on the &#9432; to check the format(while uploading it)'. This is now changed to 'CSV file uploaded is not in the supported format. Click on ⓘ (Information icon) to check the format.'

Closes Issue #143 