### PR TITLE
[feat]: Code splitting implemented through react-loadable

### DIFF
--- a/frontend/WikiContrib-Frontend/package-lock.json
+++ b/frontend/WikiContrib-Frontend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "WikiContrib-frontend",
+  "name": "wikicontrib-frontend",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -13520,6 +13520,14 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+    },
+    "react-loadable": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-loadable/-/react-loadable-5.5.0.tgz",
+      "integrity": "sha512-C8Aui0ZpMd4KokxRdVAm2bQtI03k2RMRNzOB+IipV3yxFTSVICv7WoUr5L9ALB5BmKO1iHgZtWM8EvYG83otdg==",
+      "requires": {
+        "prop-types": "^15.5.0"
+      }
     },
     "react-popper": {
       "version": "1.3.4",

--- a/frontend/WikiContrib-Frontend/package.json
+++ b/frontend/WikiContrib-Frontend/package.json
@@ -8,6 +8,7 @@
     "react": "^16.8.6",
     "react-chartjs-2": "^2.7.6",
     "react-dom": "^16.8.6",
+    "react-loadable": "^5.5.0",
     "react-router-dom": "^5.0.1",
     "react-scripts": "3.0.1",
     "semantic-ui": "^2.4.2",

--- a/frontend/WikiContrib-Frontend/src/App.js
+++ b/frontend/WikiContrib-Frontend/src/App.js
@@ -2,9 +2,27 @@ import React, { Component } from 'react';
 import './App.css';
 import { Route, Switch, BrowserRouter } from 'react-router-dom';
 import { Query } from './query';
-import QueryResult from './result';
-import NotFound from './components/404';
-import UserContribution from './contribution';
+import Loadable from 'react-loadable'
+
+const Loading = ({ error }) => {
+  if (error) return <div>Error loading component</div>
+  else return <div>Loading.....</div>
+}
+
+const QueryResult = Loadable({
+  loader: () => import('./result'),
+  loading: Loading
+})
+
+const NotFound = Loadable({
+  loader: () => import('./components/404'),
+  loading: Loading
+})
+
+const UserContribution = Loadable({
+  loader: () => import('./contribution'),
+  loading: Loading
+})
 
 /*
     All the Routers are declared here.


### PR DESCRIPTION
Imported components with `react-loadable`. It improved the performance as bundle size is reduced after implementing this.
FIxes #122 

## Screenshots
Previously:
![Screenshot from 2020-03-19 15-00-41](https://user-images.githubusercontent.com/50856599/77052302-a20d3c80-69f2-11ea-9d53-344c4f7e8fd0.png)

Now:
![Screenshot from 2020-03-19 14-58-28](https://user-images.githubusercontent.com/50856599/77052297-a0437900-69f2-11ea-9838-6e91e990561e.png)

@srish Please Review!