### PR TITLE
Revert "Fixed time calculations."

### DIFF
--- a/frontend/WikiContrib-Frontend/src/result.js
+++ b/frontend/WikiContrib-Frontend/src/result.js
@@ -72,10 +72,8 @@ const chartOptions = {
 class DisplayUser extends React.Component {
   render = () => {
     let { start_time: st, end_time: et } = this.props.filters;
-    let st = new Date(st),
-    st_m = st.getUTCMonth(),
-    et = new Date(et),
-    et_m = et.getUTCMonth();
+    st = new Date(st); let st_m = st.getUTCMonth();
+    et = new Date(et);	    et = new Date(et); let et_m = et.getUTCMonth();
     return (
       <div>
         {this.props.loading ? (

--- a/frontend/WikiContrib-Frontend/src/result.js
+++ b/frontend/WikiContrib-Frontend/src/result.js
@@ -72,8 +72,8 @@ const chartOptions = {
 class DisplayUser extends React.Component {
   render = () => {
     let { start_time: st, end_time: et } = this.props.filters;
-    st = new Date(st); let st_m = st.getUTCMonth();
-    et = new Date(et);	    et = new Date(et); let et_m = et.getUTCMonth();
+    st = new Date(st);
+    et = new Date(et);
     return (
       <div>
         {this.props.loading ? (
@@ -121,9 +121,9 @@ class DisplayUser extends React.Component {
                     )}
                 </h3>
                 <h3 className="accounts">
-                  {full_months[st_m] + " " + st.getFullYear()}
+                  {full_months[st.getUTCMonth()] + " " + st.getFullYear()}
                   -
-                  {full_months[(et_m + 11) % 12] + " " + (et_m - 1 > 0 ? et.getFullYear() : et.getFullYear() - 1)}
+                  {full_months[et.getUTCMonth() - 1] + " " + et.getFullYear()}
                 </h3>
               </span>
             </React.Fragment>


### PR DESCRIPTION
Reverts wikimedia/WikiContrib#145

@gotham3 This PR is causing error: 

```
./src/result.js
Syntax error: Identifier 'st' has already been declared (75:9)

  73 |   render = () => {
  74 |     let { start_time: st, end_time: et } = this.props.filters;
> 75 |     let st = new Date(st),
     |         ^
  76 |     st_m = st.getUTCMonth(),
  77 |     et = new Date(et),
  78 |     et_m = et.getUTCMonth();
```