### PR TITLE
[fix]: Added a directory check for uploads

### DIFF
--- a/backend/WikiContrib/Install.md
+++ b/backend/WikiContrib/Install.md
@@ -212,6 +212,7 @@ python manage.py createsuperuser
 
 The above prompts for username, email and password. The command creates a user with the corresponding username and password. You can see the database tables or models using it.
 
+> Create a `uploads` directory in the backend root directory for saving uploaded files locally.
 
 ## Run the local server:
 Finally, run the server with the command:

--- a/backend/WikiContrib/query/views.py
+++ b/backend/WikiContrib/query/views.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 from django.db import transaction, IntegrityError
 from django.db.models import Q
@@ -88,6 +89,8 @@ class AddQueryUser(CreateAPIView):
                         filename = BASE_DIR + "/uploads/" + query_obj.hash_code + ".csv.part"
                     else:
                         filename = BASE_DIR + "/uploads/" + query_obj.hash_code + ".csv"
+                    
+                    os.makedirs(os.path.dirname(filename), exist_ok=True)
 
                     with open(filename, 'wb+') as destination:
                         destination.write(request.data['csv_file'].read())


### PR DESCRIPTION
If upload directory is not present in the root backend directory the this check will automatically create the directory instead of throwing the error.
Also, updated the documentation for the same.

Fixes #142 