### PR TITLE
added server communication instruction to frontend install.md

### DIFF
--- a/frontend/WikiContrib-Frontend/Install.md
+++ b/frontend/WikiContrib-Frontend/Install.md
@@ -57,7 +57,34 @@ This installs all the requirements to the tool.
 
 ### Start the development server.
 
-Now type the following command in the same directory.
+Before starting the development server, ensure to go to "src/api.js" file
+and comment out line 
+
+`const BASE_API_URI = 'https://tools.wmflabs.org/contraband/';`
+
+As well as un-comment the line
+
+`const BASE_API_URI = 'http://127.0.0.1:8000/';`
+
+when done, both lines should look like this:
+
+`// const BASE_API_URI = 'https://tools.wmflabs.org/contraband/';`
+`const BASE_API_URI = 'http://127.0.0.1:8000/';`
+
+If you fail to do this, your react app will be communicating with 
+the production backend hosted on toolforge and not your 
+local setup of the backend.
+
+Before committing and pushing your changes, ensure to reverse it back to 
+
+`const BASE_API_URI = 'https://tools.wmflabs.org/contraband/';`
+`// const BASE_API_URI = 'http://127.0.0.1:8000/';`
+
+or your pull request won't be merged.
+
+
+
+Now type the following command in root directory (the directory with node_modules folder).
 
 ```commandline
 npm start


### PR DESCRIPTION
Prior to this PR @srish , a piece of critical information was missing in the frontend install.md file, how to communicate with your local django backend and not the hosted production server.
By default, the frontend will only be able to communicate with the hosted production server, which means a contributor won't be able to work on the backend part of the project since you won't be seeing the effects of your changes.

**Issue involved** : #130