### PR TITLE
[fix] `ReadOnlyPasswordField` implemented and `hash_code` field added in `readonly_fields`

### DIFF
--- a/backend/WikiContrib/WikiContrib/admin.py
+++ b/backend/WikiContrib/WikiContrib/admin.py
@@ -1,3 +1,6 @@
+from django import forms
+from django.contrib.auth import admin as auth_admin
+from django.contrib.auth import forms as auth_forms
 from django.contrib.admin import AdminSite
 from django.utils.translation import ugettext_lazy as _
 from django.contrib.auth.models import User, Group
@@ -11,7 +14,81 @@ class CustomAdminSite(AdminSite):
 admin_site = CustomAdminSite()
 
 # Register Auth models
-admin_site.register(User)
 admin_site.register(Group)
 
+class UserChangeForm(forms.ModelForm):
+    """
+    Replicate the form shown when the user model supplied by Django is not
+    replaced with our own by copying most of the code
+    """
 
+    password = auth_forms.ReadOnlyPasswordHashField(
+        help_text="Raw passwords are not stored, so there is no way to see "
+                  "this user's password, but you can change the password "
+                  "using <a href=\"../password/\">this form</a>.",
+    )
+
+    class Meta:
+        """
+        Meta class for UserChangeForm
+        """
+
+        model = User
+        fields = '__all__'
+
+    def __init__(self, *args, **kwargs):
+        super(UserChangeForm, self).__init__(*args, **kwargs)
+        f = self.fields.get('user_permissions', None)
+        if f is not None:
+            f.queryset = f.queryset.select_related('content_type')
+
+    def clean_password(self):
+        return self.initial["password"]
+
+
+class UserAdmin(auth_admin.UserAdmin):
+    """
+    Customize the presentation of the model User
+    """
+
+    form = UserChangeForm
+
+    fieldsets = (
+        ('Authentication', {
+            'fields': (
+                'username',
+                'password',
+            )
+        }),
+        ('Important dates', {
+            'fields': (
+                'last_login',
+                'date_joined'
+            )
+        }),
+        ('Permissions', {
+            'fields': (
+                'is_superuser',
+                'groups',
+                'user_permissions',
+            )
+        }),
+        ('Information', {
+            'fields': (
+                'first_name',
+                'last_name',
+                'email'
+            )
+        })
+    )
+
+    list_display = (
+        'username',
+        'last_login',
+        'is_superuser',
+    )
+    list_filter = tuple()
+
+    search_fields = ['id', 'username' ]
+
+admin_site.register(User, UserAdmin)

--- a/backend/WikiContrib/query/admin.py
+++ b/backend/WikiContrib/query/admin.py
@@ -1,6 +1,27 @@
-from WikiContrib.admin import admin_site as admin
+from django.contrib import admin
+from WikiContrib.admin import admin_site
 from .models import Query, QueryFilter, QueryUser
 
-admin.register(Query)
-admin.register(QueryFilter)
-admin.register(QueryUser)
+class QueryAdmin(admin.ModelAdmin):  
+    """
+    Customize the presentation of the model Query
+    """
+
+    fields = (
+        'hash_code', 
+        'file', 
+        'csv_file', 
+        'created_on'
+    )
+    list_display = (
+        'hash_code',
+        'file',
+        'created_on'
+    )
+    readonly_fields = [
+        'hash_code'
+    ]
+
+admin_site.register(Query, QueryAdmin)
+admin_site.register(QueryFilter)
+admin_site.register(QueryUser)


### PR DESCRIPTION
`ReadOnlyPasswordField` with password change form implemented in place of normal password field and fields added in `list_display` for better readability.
`hash_code` field is included in readonly_fields and fields added in `list_display`.

Fixes #136

## Before User Admin model:

![Screenshot from 2020-03-24 18-19-22](https://user-images.githubusercontent.com/50856599/77427545-9eb3ef80-6dfc-11ea-8018-8ab58fc8b839.png)
![Screenshot from 2020-03-24 18-19-17](https://user-images.githubusercontent.com/50856599/77427550-a07db300-6dfc-11ea-8be1-a5b26fccf562.png)

## After User Admin model:

![Screenshot from 2020-03-24 18-17-17](https://user-images.githubusercontent.com/50856599/77427609-b1c6bf80-6dfc-11ea-96f8-77631db3a0e5.png)
![Screenshot from 2020-03-24 18-17-49](https://user-images.githubusercontent.com/50856599/77427578-a7a4c100-6dfc-11ea-852e-4ee306f69885.png)
![Screenshot from 2020-03-24 18-17-53](https://user-images.githubusercontent.com/50856599/77427586-a96e8480-6dfc-11ea-9128-098c9564c111.png)

## Before Query Admin model:

![Screenshot from 2020-03-24 18-19-39](https://user-images.githubusercontent.com/50856599/77427521-91970080-6dfc-11ea-9c9f-b040ca3cedbd.png)
![Screenshot from 2020-03-24 18-19-42](https://user-images.githubusercontent.com/50856599/77427490-8643d500-6dfc-11ea-8f2f-777b1a5cbd80.png)

## After Query Admin model:

![Screenshot from 2020-03-24 18-17-04](https://user-images.githubusercontent.com/50856599/77427831-13872980-6dfd-11ea-85d2-e56b0b2cdef6.png)
![Screenshot from 2020-03-24 18-17-10](https://user-images.githubusercontent.com/50856599/77427612-b2f7ec80-6dfc-11ea-9f7e-f82a1b9df929.png)