### PR TITLE
automated backend url selection based on environment

### DIFF
--- a/frontend/WikiContrib-Frontend/src/api.js
+++ b/frontend/WikiContrib-Frontend/src/api.js
@@ -2,15 +2,16 @@
  All the Global Constants are declared here.
 */
 
-const BASE_API_URI = 'https://tools.wmflabs.org/contraband/';
-// const BASE_API_URI = 'http://127.0.0.1:8000/';
+const BASE_API_URI = process.env.NODE_ENV === 'production' ?
+                     'https://tools.wmflabs.org/contraband/'
+                  :  'http://127.0.0.1:8000/';
 
 // method: POST
 export const QueryCreateApi = BASE_API_URI + 'query/add/user/';
 // method: GET, PATCH, DELETE
 export const QueryDetailApi = BASE_API_URI + 'query/<hash>/update/user/';
 // method: POST
-export const filterCreateApi = BASE_API_URI + 'query/<hash>/add/filter/'; 
+export const filterCreateApi = BASE_API_URI + 'query/<hash>/add/filter/';
 // method: GET, PATCH, DELETE
 export const filterDetailApi = BASE_API_URI + 'query/<hash>/update/filter/';
 // method: POST


### PR DESCRIPTION
Prior to this PR, a contributor still has to manually select URL to use to connect to the backend based on whether it's development or production environment. This issue was addressed in this PR @srish 

**Issue fixed : #165**