### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/backend/WikiContrib/requirements.txt
+++ b/backend/WikiContrib/requirements.txt
@@ -10,7 +10,6 @@ django-cleanup==3.2.0
 django-cors-headers==3.0.2
 django-environ==0.4.5
 djangorestframework==3.9.4
-fuzzywuzzy==0.18.0
 idna==2.8
 idna-ssl==1.1.0
 multidict==4.5.2
@@ -18,8 +17,8 @@ numpy==1.16.4
 pandas==0.24.2
 pycparser==2.19
 python-dateutil==2.8.0
-python-Levenshtein==0.12.0
 pytz==2019.1
+rapidfuzz==0.9.1
 six==1.12.0
 sqlparse==0.3.0
 typing-extensions==3.7.4

--- a/backend/WikiContrib/result/views.py
+++ b/backend/WikiContrib/result/views.py
@@ -18,7 +18,7 @@ from pytz import utc
 from WikiContrib.settings import API_TOKEN
 from .helper import get_prev_user, get_next_user
 import sys
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 version = sys.hexversion
 version_3_3 = 50530288


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy