### PR TITLE
renamed "owned" to "authored" project wide

### DIFF
--- a/backend/WikiContrib/result/models.py
+++ b/backend/WikiContrib/result/models.py
@@ -16,7 +16,7 @@ class ListCommit(models.Model):
     createdEnd = models.DateTimeField(default=timezone.now)
     redirect = models.CharField(max_length=200)
     status = models.CharField(max_length=20)
-    owned = models.BooleanField(default=False)
+    authored = models.BooleanField(default=False)
     assigned = models.BooleanField(default=False)
 
     def __str__(self):

--- a/backend/WikiContrib/result/serializers.py
+++ b/backend/WikiContrib/result/serializers.py
@@ -8,4 +8,4 @@ class UserCommitSerializer(ModelSerializer):
     """
     class Meta:
         model = ListCommit
-        fields = ('heading', 'platform', 'redirect', 'owned', 'assigned', 'status')
+        fields = ('heading', 'platform', 'redirect', 'authored', 'assigned', 'status')

--- a/backend/WikiContrib/result/views.py
+++ b/backend/WikiContrib/result/views.py
@@ -410,7 +410,7 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
     """ If there are matching results in the cache """
     if cachedResults != None:
         results = loads(serialize("json", cachedResults, fields = ("created_on",
-                    "platform", "status", "owned", "assigned")))
+                    "platform", "status", "authored", "assigned")))
         for result in results:
             status = result["fields"]["status"].lower()
             if (status_name is True or status in status_name or
@@ -419,7 +419,7 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
                         result["fields"]["created_on"].split("Z")[0],"%Y-%m-%dT%H:%M:%S"))
                 rv = {
                    "time": time.isoformat(), "platform":result["fields"]["platform"],
-                   "staus":result["fields"]["status"], "owned":result["fields"]["owned"],
+                   "staus":result["fields"]["status"], "authored":result["fields"]["authored"],
                    "assigned":result["fields"]["assigned"]
                 }
                 resp.append(rv)
@@ -455,7 +455,7 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
                             createdStart = query.queryfilter.start_time,
                             createdEnd = query.queryfilter.end_time,
                             platform = "Gerrit", status = change['status'],
-                            redirect = change['change_id'], owned = True,
+                            redirect = change['change_id'], authored = True,
                             assigned = True
                         )
 
@@ -463,7 +463,7 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
                     or (status == "open" in status_name)):
                         rv = {
                            "time": contrib.created_on.isoformat(), "platform":contrib.platform,
-                           "staus":contrib.status, "owned":contrib.owned,
+                           "staus":contrib.status, "authored":contrib.authored,
                            "assigned":contrib.assigned
                         }
                         resp.append(rv)
@@ -488,14 +488,14 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
                                 createdStart = query.queryfilter.start_time,
                                 createdEnd = query.queryfilter.end_time,
                                 platform = "Phabricator", status = pd[i]['fields']['status']['name'],
-                                redirect = "T" + str(pd[i]['id']), owned = pd[i]['fields']['authorPHID'] == phid,
+                                redirect = "T" + str(pd[i]['id']), authored = pd[i]['fields']['authorPHID'] == phid,
                                 assigned = pd[i]['fields']['ownerPHID'] == True or phid == pd[i]['fields']['ownerPHID']
                                 )
                         if (status_name is True or status in status_name
                         or (status == "open" and "p-open" in status_name)):
                             rv = {
                                 "time": contrib.created_on.isoformat(), "platform": contrib.platform,
-                                "status": contrib.status, "owned": contrib.owned,
+                                "status": contrib.status, "authored": contrib.authored,
                                 "assigned": contrib.assigned
                                  }
                             resp.append(rv)
@@ -520,12 +520,12 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
                                             createdStart = query.queryfilter.start_time,
                                             createdEnd = query.queryfilter.end_time,
                                             platform = "Github", status = "merged", assigned = True,
-                                            redirect = ghd[i]["html_url"], owned = True,
+                                            redirect = ghd[i]["html_url"], authored = True,
                                         )
 
                                     rv = {
                                        "time": contrib.created_on.isoformat(), "platform":contrib.platform,
-                                       "staus":contrib.status, "owned":contrib.owned,
+                                       "staus":contrib.status, "authored":contrib.authored,
                                        "assigned":contrib.assigned
                                     }
                                     resp.append(rv)
@@ -546,12 +546,12 @@ def format_data(ghd_rate_limit_message,unique_user_hash = None, pd = None, gd = 
                                         createdStart = query.queryfilter.start_time,
                                         createdEnd = query.queryfilter.end_time,
                                         platform = "Github", status="merged", assigned = True,
-                                        redirect = ghd[i]["html_url"], owned = True,
+                                        redirect = ghd[i]["html_url"], authored = True,
                                     )
 
                                 rv = {
                                    "time": contrib.created_on.isoformat(), "platform":contrib.platform,
-                                   "staus":contrib.status, "owned":contrib.owned,
+                                   "staus":contrib.status, "authored":contrib.authored,
                                    "assigned":contrib.assigned
                                 }
                                 resp.append(rv)
@@ -1011,7 +1011,7 @@ def UserUpdateStatus(data):
         obj = {
             "time": i.created_on,
             "status": i.status,
-            "owned": i.owned,
+            "authored": i.authored,
             "assigned": i.assigned
         }
 

--- a/docs/Internal Working.rst
+++ b/docs/Internal Working.rst
@@ -63,7 +63,7 @@ So, even if I want to get some page **n** you have to get all the details from *
 
 In this tool, all the contributions of the user from Gerrit are being fetched. But in the case of phabricator, two kinds of tasks are taken into count:
 
-1. Tasks owned by the user.
+1. Tasks authored by the user.
 2. Tasks assigned to the user.
 
 For Github, we are only concerned with the contributors commits.
@@ -109,7 +109,7 @@ If the query is not in the cache or is more than a day old in the cache, we call
 The above code adds four tasks to the event loop. Each of the tasks fetches contributions data through the various APIs.
 
 1. ``get_gerrit_data()``: fetch contributions user from gerrit.
-2. ``get_task_authors()``: fetch tasks owned by a user in phabricator.
+2. ``get_task_authors()``: fetch tasks authored by a user in phabricator.
 3. ``get_task_assigner()``: fetch tasks assigned to a user in phabricator.
 4. ``get_github_data()``: fetches contributions to a given set of Wikimedia repositories on github.
 

--- a/docs/_build/html/Internal Working.html
+++ b/docs/_build/html/Internal Working.html
@@ -194,7 +194,7 @@ be parallel because each page has to be requested with a reference(except the fi
 <p>So, even if I want to get some page <strong>n</strong> you have to get all the details from <strong>1 to n</strong>.</p>
 <p>In this tool, all the contributions of the user from Gerrit are being fetched. But in the case of phabricator, two kinds of tasks are taken into count:</p>
 <ol class="arabic simple">
-<li><p>Tasks owned by the user.</p></li>
+<li><p>Tasks authored by the user.</p></li>
 <li><p>Tasks assigned to the user.</p></li>
 </ol>
 <p>For Github, we are only concerned with the contributors commits.</p>
@@ -222,7 +222,7 @@ If the query is not in the cache or is more than a day old in the cache, we call
 <p>The above code adds four tasks to the event loop. Each of the tasks fetches contributions data through the various APIs.</p>
 <ol class="arabic simple">
 <li><p><code class="docutils literal notranslate"><span class="pre">get_gerrit_data()</span></code>: fetch contributions user from gerrit.</p></li>
-<li><p><code class="docutils literal notranslate"><span class="pre">get_task_authors()</span></code>: fetch tasks owned by a user in phabricator.</p></li>
+<li><p><code class="docutils literal notranslate"><span class="pre">get_task_authors()</span></code>: fetch tasks authored by a user in phabricator.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">get_task_assigner()</span></code>: fetch tasks assigned to a user in phabricator.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">get_github_data()</span></code>: fetches contributions to a given set of Wikimedia repositories on github.</p></li>
 </ol>

--- a/docs/_build/html/Working.html
+++ b/docs/_build/html/Working.html
@@ -175,7 +175,7 @@ Suppose if you have to get the commits of the user in 7th page, you have to requ
 <p>So, even if I want to get some page <strong>n</strong> you have to get all the details from <strong>1 to n</strong>.</p>
 <p>In this tool, all the contributions of the user from gerrit are being fetched. But in case of phabricator, two kinds of tasks are taken into count:</p>
 <ol class="arabic simple">
-<li><p>Tasks owned by the user.</p></li>
+<li><p>Tasks authored by the user.</p></li>
 <li><p>Tasks assigned to the user.</p></li>
 </ol>
 <p><strong>DisplayResult</strong> view actually gets all the data required to perform the extrnal API requests and call another function <code class="docutils literal notranslate"><span class="pre">getDetails</span></code>. This function takes the data and format them according to the requirement. It also creates a new <strong>asyncio event loop</strong>.
@@ -192,7 +192,7 @@ This loop is given with three different co-routines. (If you are not familiar wi
 <p>The above code adds three tasks to the event loop. Each of the task fetches APIs and get information.</p>
 <ol class="arabic simple">
 <li><p><code class="docutils literal notranslate"><span class="pre">get_gerrit_data()</span></code>: fetch contributions user from gerrit.</p></li>
-<li><p><code class="docutils literal notranslate"><span class="pre">get_task_authors()</span></code>: fetch tasks owned by a user in phabricator.</p></li>
+<li><p><code class="docutils literal notranslate"><span class="pre">get_task_authors()</span></code>: fetch tasks authored by a user in phabricator.</p></li>
 <li><p><code class="docutils literal notranslate"><span class="pre">get_task_assigner()</span></code>: fetch tasks assigned to a user in phabricator.</p></li>
 </ol>
 <p><code class="docutils literal notranslate"><span class="pre">get_gerrit_data()</span></code> perform a single API request and gets all the details of the users.

--- a/docs/_build/html/_sources/Internal Working.rst.txt
+++ b/docs/_build/html/_sources/Internal Working.rst.txt
@@ -63,7 +63,7 @@ So, even if I want to get some page **n** you have to get all the details from *
 
 In this tool, all the contributions of the user from Gerrit are being fetched. But in the case of phabricator, two kinds of tasks are taken into count:
 
-1. Tasks owned by the user.
+1. Tasks authored by the user.
 2. Tasks assigned to the user.
 
 For Github, we are only concerned with the contributors commits.
@@ -109,7 +109,7 @@ If the query is not in the cache or is more than a day old in the cache, we call
 The above code adds four tasks to the event loop. Each of the tasks fetches contributions data through the various APIs.
 
 1. ``get_gerrit_data()``: fetch contributions user from gerrit.
-2. ``get_task_authors()``: fetch tasks owned by a user in phabricator.
+2. ``get_task_authors()``: fetch tasks authored by a user in phabricator.
 3. ``get_task_assigner()``: fetch tasks assigned to a user in phabricator.
 4. ``get_github_data()``: fetches contributions to a given set of Wikimedia repositories on github.
 

--- a/docs/_build/html/_sources/Working.rst.txt
+++ b/docs/_build/html/_sources/Working.rst.txt
@@ -33,7 +33,7 @@ So, even if I want to get some page **n** you have to get all the details from *
 
 In this tool, all the contributions of the user from gerrit are being fetched. But in case of phabricator, two kinds of tasks are taken into count:
 
-1. Tasks owned by the user.
+1. Tasks authored by the user.
 2. Tasks assigned to the user.
 
 **DisplayResult** view actually gets all the data required to perform the extrnal API requests and call another function ``getDetails``. This function takes the data and format them according to the requirement. It also creates a new **asyncio event loop**.
@@ -52,7 +52,7 @@ This loop is given with three different co-routines. (If you are not familiar wi
 The above code adds three tasks to the event loop. Each of the task fetches APIs and get information. 
 
 1. ``get_gerrit_data()``: fetch contributions user from gerrit.
-2. ``get_task_authors()``: fetch tasks owned by a user in phabricator.
+2. ``get_task_authors()``: fetch tasks authored by a user in phabricator.
 3. ``get_task_assigner()``: fetch tasks assigned to a user in phabricator.
 
 ``get_gerrit_data()`` perform a single API request and gets all the details of the users.

--- a/frontend/WikiContrib-Frontend/src/result.js
+++ b/frontend/WikiContrib-Frontend/src/result.js
@@ -265,7 +265,7 @@ class QueryResult extends React.Component {
             lineTension: 0.4,
           },
           {
-            label: 'Owned',
+            label: 'Authored',
             data: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
             borderColor: 'rgba(255, 204, 51, 0.6)',
             backgroundColor: 'rgba(255, 204, 51, 0.2)',
@@ -308,7 +308,7 @@ class QueryResult extends React.Component {
       let et_y = et.getFullYear();
 
       if (platform === 'phabricator' && e.platform.toLowerCase() === platform) {
-        if (e.assigned && !e.owned) {
+        if (e.assigned && !e.authored) {
             if (index === et_m && index_year === et_y) {
               current_month[0] += 1;
               current_month[2] += 1;
@@ -316,7 +316,7 @@ class QueryResult extends React.Component {
               data.datasets[0].data[index] += 1;
               data.datasets[2].data[index] += 1;
             }
-        } else if (e.owned && !e.assigned) {
+        } else if (e.authored && !e.assigned) {
           if (index === et_m && index_year === et_y) {
             current_month[1] += 1;
             current_month[2] += 1;


### PR DESCRIPTION
Prior to this PR, we used "owned" to represent phabricator tasks created by a user. This can lead to confusion and ambiguity because "own" means something else in phabricator diffusion. In this PR, I changed "owned" to "authored" project wide.

**issue fixed**: #243 