### PR TITLE
Expand title attribute

### DIFF
--- a/frontend/WikiContrib-Frontend/public/index.html
+++ b/frontend/WikiContrib-Frontend/public/index.html
@@ -20,7 +20,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>WikiContrib</title>
+  <title>WikiContrib — Visualize your technical contributions or a fellow Wikimedian's to Wikimedia projects!</title>
 </head>
 
 <body>


### PR DESCRIPTION
Motivation: I couldn't remember the URL of this tool, and wasn't finding it in my browser history because I was searching for "contributions" (I remembered that word appeared on the page) but not "contrib". 

A shorter variant on my proposed change would be `WikiContrib — Visualize technical contributions to Wikimedia projects!`